### PR TITLE
multiple corpus locations as input to fuzzing, and change default output corpus location

### DIFF
--- a/fuzz/packages.go
+++ b/fuzz/packages.go
@@ -40,7 +40,6 @@ func (f *Func) String() string {
 // suggests not allowing something like 'go test -fuzz=. ./...' to match multiple fuzz functions.
 // As an experiment, allowMultiFuzz flag allows that.
 // FindFunc searches for a requested function to visit.
-// TODO: from richsig
 func FindFunc(pkgPattern, funcPattern string, env []string, allowMultiFuzz bool) ([]Func, error) {
 	report := func(err error) error {
 		return fmt.Errorf("error while loading packages for pattern %v: %v", pkgPattern, err)

--- a/fuzz/richsig_test.go
+++ b/fuzz/richsig_test.go
@@ -18,8 +18,6 @@ func TestWrapperGeneration(t *testing.T) {
 		args       args
 		wantOutput string
 		wantErr    bool
-		// TODO: delete? update? not use currently.
-		// want    []Func
 	}{
 		{
 			name:    "only basic types: string, []byte, bool",
@@ -147,21 +145,17 @@ func fuzzOne (fuzzer *randparam.Fuzzer) {
 			var b bytes.Buffer
 			functions, err := FindFunc(tt.args.pkgPattern, tt.args.funcPattern, nil, tt.args.allowMultiFuzz)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("FindFunc() error = %v, wantErr %v", err, tt.wantErr)
-				return
+				t.Fatalf("FindFunc() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			createWrapper(&b, functions[0])
+			err = createWrapper(&b, functions[0])
+			if err != nil {
+				t.Fatalf("createWrapper() error = %v", err)
+			}
 			gotOutput := b.String()
 			diff := cmp.Diff(tt.wantOutput, gotOutput)
 			if diff != "" {
-				t.Fatalf("FindFunc() failed to match function output. diff:\n%s", diff)
+				t.Fatalf("createWrapper() failed to match function output. diff:\n%s", diff)
 			}
-
-			/* TODO: delete? update?
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FindFunc() = %v, want %v", got, tt.want)
-			}
-			*/
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -6,9 +6,10 @@
 // 1. cacheDir is the location for the instrumented binary, and would typically be something like:
 //      GOPATH/pkg/fuzz/linux_amd64/619f7d77e9cd5d7433f8/fmt.FuzzFmt
 // 2. fuzzDir is the directory supplied via the -fuzzdir argument, and contains the workDir.
-// 3. workDir is passed to go-fuzz as the -workdir argument.
-//      if -fuzzdir is specified,  workDir is fuzzdir/<fuzzname>
-//      if -fuzzdir is not specified, workDir is pkgpath/testdata/fuzz/<fuzzname>
+// 3. workDir is passed to go-fuzz-build and go-fuzz as the -workdir argument.
+//      if -fuzzdir is not specified:  workDir is GOPATH/pkg/fuzz/corpus/<import-path>/<func>
+//      if -fuzzdir is '/some/path':   workDir is /some/path/<import-path>/<func>
+//      if -fuzzdir is 'testdata':     workDir is <pkg-dir>/testdata/fuzz/<func>
 package main
 
 import (
@@ -79,7 +80,7 @@ func fzgoMain() int {
 
 	if os.Args[1] != "test" {
 		// pass through to 'go' command
-		err := fuzz.ExecGo(os.Args[1:], nil)
+		err = fuzz.ExecGo(os.Args[1:], nil)
 		if err != nil {
 			// ExecGo prints error if 'go' tool is not in path.
 			// Other than that, we currently rely on the 'go' tool to print any errors itself.
@@ -147,7 +148,7 @@ func fzgoMain() int {
 		fmt.Printf("fzgo: found functions %s\n", strings.Join(names, ", "))
 	}
 
-	// build our instrumented code, or find it already built in the fzgo cache
+	// build our instrumented code, or find if is is already built in the fzgo cache
 	var targets []fuzz.Target
 	for _, function := range functions {
 		target, err := fuzz.Instrument(function, flagVerbose)
@@ -168,13 +169,14 @@ func fzgoMain() int {
 	timeQuantum := 5 * time.Second
 	for {
 		for _, target := range targets {
-			// pull our last bit of info out of our arguments, then start fuzzing.
-			// TODO: Currently calculating this > 1 time in main.go.
-			var workDir string
-			if flagFuzzDir == "" {
-				workDir = filepath.Join(target.UserFunc.PkgDir, "testdata", "fuzz", target.FuzzName())
-			} else {
-				workDir = filepath.Join(flagFuzzDir, target.FuzzName())
+			// pull our last bit of info out of our arguments.
+			workDir := determineWorkDir(target.UserFunc, flagFuzzDir)
+
+			// seed our workDir with any other corpus that might exist from other known locations.
+			// see comment for copyCachedCorpus for discussion of current behavior vs. desired behavior.
+			if err = copyCachedCorpus(target.UserFunc, workDir); err != nil {
+				fmt.Println("fzgo:", err)
+				return OtherErr
 			}
 
 			// determine how long we will execute this particular fuzz invocation.
@@ -216,7 +218,7 @@ func fzgoMain() int {
 // args is os.Args
 func verifyCorpus(args []string) int {
 	// we do this by first searching for any fuzz func ("." regexp) in our package pattern.
-	// TODO: move this elsewhere. Taken from fuzz.ParseArgs.
+	// TODO: move this elsewhere? Taken from fuzz.ParseArgs, but we can't use fuzz.ParseArgs as is.
 	testPkgPatterns, nonPkgArgs, err := fuzz.FindPkgs(args[2:])
 	if err != nil {
 		fmt.Println("fzgo:", err)
@@ -239,27 +241,112 @@ func verifyCorpus(args []string) int {
 	}
 	// TODO: should we get -v? E.g., something like:
 	// _, verbose := fuzz.FindTestFlag(os.Args[2:], []string{"v"})
+
 	status := Success
 	for _, function := range functions {
-		fuzzName := function.FuzzName()
-		var workDir string
+
+		// work through how many places we need to check based on
+		// what the user specified in flagFuzzDir.
+		var dirsToCheck []string
+
+		// we always check the "testdata" dir if it exists.
+		testdataWorkDir := determineWorkDir(function, "testdata")
+		dirsToCheck = append(dirsToCheck, testdataWorkDir)
+
+		// we also always check under  GOPATH/pkg/fuzz/corpus/... if it exists.
+		gopathPkgWorkDir := determineWorkDir(function, "")
+		dirsToCheck = append(dirsToCheck, gopathPkgWorkDir)
+
+		// see if we need to check elsewhere as well.
 		if flagFuzzDir == "" {
-			workDir = filepath.Join(function.PkgDir, "testdata", "fuzz", fuzzName)
+			// nothing else to do; the user did not specify a dir.
+		} else if flagFuzzDir == "testdata" {
+			// nothing else to do; we already added testdata dir.
 		} else {
-			workDir = filepath.Join(flagFuzzDir, fuzzName)
+			// the user supplied a destination
+			userWorkDir := determineWorkDir(function, flagFuzzDir)
+			dirsToCheck = append(dirsToCheck, userWorkDir)
 		}
-		err := fuzz.VerifyCorpus(function, workDir, nonPkgArgs)
-		if err == fuzz.ErrGoTestFailed {
-			// 'go test' itself should have printed an informative error,
-			// so here we just set a non-zero status code and continue.
-			status = OtherErr
-		} else if err != nil {
-			fmt.Println("fzgo:", err)
-			return OtherErr
+
+		// we have 2 or 3 places to check
+		for _, workDir := range dirsToCheck {
+			if !fuzz.PathExists(workDir) {
+				// this workDir does not exist, so skip
+				continue
+			}
+
+			err := fuzz.VerifyCorpus(function, workDir, nonPkgArgs)
+			if err == fuzz.ErrGoTestFailed {
+				// 'go test' itself should have printed an informative error,
+				// so here we just set a non-zero status code and continue.
+				status = OtherErr
+			} else if err != nil {
+				fmt.Println("fzgo:", err)
+				return OtherErr
+			}
 		}
 	}
 
 	return status
+}
+
+// determineWorkDir translates from the user's specified -fuzzdir to an actual
+// location on disk, including the default location if the user does not specify a -fuzzdir.
+func determineWorkDir(function fuzz.Func, requestedFuzzDir string) string {
+	var workDir string
+	importPathDirs := filepath.FromSlash(function.PkgPath) // convert import path into filepath
+	if requestedFuzzDir == "" {
+		// default to GOPATH/pkg/fuzz/corpus/import/path/<func>
+		gp := fuzz.Gopath()
+		workDir = filepath.Join(gp, "pkg", "fuzz", "corpus", importPathDirs, function.FuncName)
+	} else if requestedFuzzDir == "testdata" {
+		// place under the package of interest in the testdata directory.
+		workDir = filepath.Join(function.PkgDir, "testdata", "fuzz", function.FuncName)
+	} else {
+		// requestedFuzzDir was specified to be an actual directory.
+		// still use the import path to handle fuzzing multiple functions across multiple packages.
+		workDir = filepath.Join(requestedFuzzDir, importPathDirs, function.FuncName)
+	}
+	return workDir
+}
+
+// copyCachedCorpus desired bheavior (or at least proposed-by-me behavior):
+//     1. if destination corpus location doesn't exist, seed it from GOPATH/pkg/fuzz/corpus/import/path/<fuzzfunc>
+//     2. related: fuzz while reading from all known locations that exist (e.g,. testdata if it exists, GOPATH/pkg/fuzz/corpus/...)
+//
+// However, 2. is not possible currently to do directly with dvyukov/go-fuzz for more than 1 corpus.
+//
+// Therefore, the current behavior of copyCachedCorpus approximates 1. and 2. like so:
+//     1'. always copy all known corpus entries to the destination corpus location in all cases.
+//
+// Also, that current behavior could be reasonable for the proposed behavior in the sense that it is simple.
+// Filenames that already exist in the destination are not updated.
+// TODO: it is debatable if it should copy crashers and suppressions as well.
+// For clarity, it only copies the corpus directory itself, and not crashers and supressions.
+// This avoids making sometone think they have a new crasher after copying a crasher to a new location, for example,
+// especially at this current prototype phase where the crasher reporting in
+// go-fuzz does not know anything about multi-corpus locations.
+func copyCachedCorpus(function fuzz.Func, dstWorkDir string) error {
+	dstCorpusDir := filepath.Join(dstWorkDir, "corpus")
+
+	gopathPkgWorkDir := determineWorkDir(function, "")
+	testdataWorkDir := determineWorkDir(function, "testdata")
+
+	for _, srcWorkDir := range []string{gopathPkgWorkDir, testdataWorkDir} {
+		srcCorpusDir := filepath.Join(srcWorkDir, "corpus")
+		if srcCorpusDir == dstCorpusDir {
+			// nothing to do
+			continue
+		}
+		if fuzz.PathExists(srcCorpusDir) {
+			// copyDir will create dstDir if needed, and won't overwrite files
+			// in dstDir that already exist.
+			if err := fuzz.CopyDir(dstCorpusDir, srcCorpusDir); err != nil {
+				return fmt.Errorf("failed seeding destination corpus: %v", err)
+			}
+		}
+	}
+	return nil
 }
 
 func usage(fs *flag.FlagSet) func() {

--- a/testscripts/fuzzing_rich_signatures.txt
+++ b/testscripts/fuzzing_rich_signatures.txt
@@ -1,14 +1,11 @@
 # Test fuzzing rich sigs. We could assume go-fuzz and go-fuzz-build binaries are in the path,
 # but we start these tests doing 'go get' on github.com/dvyukov/go-fuzz/... because we need
 # the go-fuzz-dep source code to be findable by go-fuzz-build (when it invokes 'go list').
-
-# TODO: clean up write up, pull in other permutations from fuzzing.txt
+# Reminder: the tests here can be run by themselves from the fzgo directory via:
+#    go test -run=TestScripts/fuzzing_rich_signatures .
 
 # Exit early if -short was specified.
 [short] skip 'skipping building instrumented binary because -short was specified'
-
-# sanity check upfront
-exists $WORK/gopath/src/sample/richsignatures
 
 # get our dependencies
 go get -v -u github.com/thepudds/fzgo/...
@@ -28,22 +25,23 @@ exists $WORK/gopath/bin/go-fuzz-build$exe
 
 # First fuzz test: no fzgo cache, so we build the instrumented binary from scratch.
 # This also creates our corpus directory in the default location.
-fzgo test -fuzz=FuzzWithBasicTypes sample/richsignatures -fuzztime=5s
+fzgo test -fuzz=FuzzWithBasicTypes example.com/richsignatures -fuzztime=5s
 stdout 'building instrumented binary for pkgname.FuzzWithBasicTypes'
 stderr 'workers: \d+, corpus: '
-exists $WORK/gopath/src/sample/richsignatures/testdata/fuzz/pkgname.FuzzWithBasicTypes/corpus
+exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzWithBasicTypes/corpus
 
 # Second fuzz test: now we use the fzgo cache.
-fzgo test -fuzz=FuzzWithBasicTypes sample/richsignatures -fuzztime=5s
+# We also specify -parallel=1 to reduce CPU usage for our remaining tests.
+fzgo test -fuzz=FuzzWithBasicTypes example.com/richsignatures -parallel=1 -fuzztime=5s
 stdout 'fzgo: using cached instrumented binary for pkgname.FuzzWithBasicTypes'
 stderr 'workers: \d+, corpus: '
 
 # Flag -fuzzdir controls where the corpus goes (which could be in a different repo). 
 # This invocation still uses the cache, as do all subsequent invocations in this script.
-fzgo test -fuzz=FuzzWithBasicTypes sample/richsignatures -fuzztime=5s -fuzzdir=$WORK/myfuzzdir
+fzgo test -fuzz=FuzzWithBasicTypes example.com/richsignatures -parallel=1 -fuzztime=5s -fuzzdir=$WORK/myfuzzdir
 stdout 'fzgo: using cached instrumented binary for pkgname.FuzzWithBasicTypes'
 stderr 'workers: \d+, corpus: '
-exists $WORK/myfuzzdir/pkgname.FuzzWithBasicTypes/corpus
+exists $WORK/myfuzzdir/example.com/richsignatures/FuzzWithBasicTypes/corpus
 
 # Uncomment this next line if you don't want to rely on goimports
 # [!exec:goimports] stop 'skipping remaining step that currently relies on goimports being in the path'
@@ -54,21 +52,21 @@ stderr 'goimports'
 
 # Check rich signature from stdlib (uses regexp)
 # This currently relies on goimports being in the path.
-fzgo test -fuzz=FuzzWithStdlibType sample/richsignatures -fuzztime=5s
+fzgo test -fuzz=FuzzWithStdlibType example.com/richsignatures -parallel=1 -fuzztime=5s
 stdout 'building instrumented binary for pkgname.FuzzWithStdlibType'
 stderr 'workers: \d+, corpus: '
-exists $WORK/gopath/src/sample/richsignatures/testdata/fuzz/pkgname.FuzzWithStdlibType/corpus
+exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzWithStdlibType/corpus
 
 # Check we can get a crasher relatively quickly by finding a 64 bit int via a rich signature, which
-# should imply go-fuzz literal injection is working end-to-end with rich signatures.
-fzgo test -fuzz=FuzzHardToGuessNumber sample/richsignatures -fuzztime=20s
+# should imply go-fuzz literal injection is working end-to-end with fzgo's rich signatures.
+fzgo test -fuzz=FuzzHardToGuessNumber example.com/richsignatures -parallel=1 -fuzztime=10s
 stdout 'building instrumented binary for pkgname.FuzzHardToGuessNumber'
 stderr 'workers: \d+, corpus: .* crashers: [^0]'
-exists $WORK/gopath/src/sample/richsignatures/testdata/fuzz/pkgname.FuzzHardToGuessNumber/corpus
+exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzHardToGuessNumber/corpus
 
-# TODO: currently this is cloned from examples dir in fzgo repo
+# NOTE: currently this is cloned from examples dir in fzgo repo. (Probably good to have locally here?)
 
--- gopath/src/sample/richsignatures/richsignatures.go --
+-- gopath/src/example.com/richsignatures/richsignatures.go --
 package pkgname
 
 import (


### PR DESCRIPTION
This adds support for multiple corpus locations as input to fuzzing.

### Destinations for new corpus entries

There are three possible destinations for writing new corpus entries, in decreasing order of sophistication or work needed on the part of the user:

*  `-fuzzdir=/some/path`: Corpus is written to the user-specified directory (perhaps outside of VCS, perhaps ultimately stored as a tar.gz in blob storage, perhaps a separate `foo-corpus` repo)
*  `-fuzzdir=testdata`: Corpus is written to `<pkg-path>/testdata/fuzz/<func>` for all matching fuzz functions (and therefore, most often in same VCS repo as the code under test)
*  `-fuzzdir` not set: Default to writing corpus under `GOPATH/pkg/fuzz/corpus/...` 

### Three rules for what corpus gets read, what corpus gets written

There are three simple rules for what corpus gets read, and what gets written:

 1. fzgo always reads from all known corpus sources that exist. 
 2. fzgo always writes only to the user's requested destination (with a reasonable default if `-fuzzdir` is not specified)
 3. if the destination does already not exist for a particular function being fuzzed, fzgo seeds the destination with any matching corpus elements present in any of the other known corpus locations from that function. 

The last rule helps with transitioning from one location to another, without needing to manually hunt around or writing a `cp` script, which is important especially if you have many fuzz functions or packages being fuzzed.

### Additional details and rationale

`GOPATH/pkg/fuzz/corpus/...` is a convenient default location, with some nice attributes:
 * It means you don't end up with a dirty VCS status by default if you are fuzzing your own code. (It is fairly annoying to dirty your VCS status if you don't intend to, especially if you are just fuzzing for a brief period of time).
 * It works even if the code under test is stored in a read-only `<pkg-path>` (which is the common case for a dependency under modules, which are stored in a read-only module cache).
 * The user doesn't need to think about where to store their corpus, which is convenient if you are starting out or just doing brief amounts of fuzzing.
 * The user didn't need to set up anything else (e.g., did not need to set up a separate repo, did not need to set up some other shared storage, etc.).
 * The corpus is saved _somewhere_, and it will be re-used when you fuzz again on that machine.

That said, defaulting to `GOPATH/pkg/fuzz/corpus/...` means that location is typically local to the current machine, and not shared with anyone else. That's fine if you are fuzzing for "minutes" or "hours", because even if you lose a machine you can mostly regain that CPU time spent by kicking off a fuzz run over night, or over the weekend, etc.  However, if you have been fuzzing for "days" or "weeks", you probably want to store your corpus somewhere more permanent and more shareable, at which point you need to make a decision: store it in VCS along with your code under test (`-fuzzdir=testdadta`), or store it somewhere else under your control (`-fuzzdir=/some/path`) however you see fit.

In order to make that transition from "I've been fuzzing locally and not been too worried about sharing my corpus" to "I want a more permanent or more shareable location for my corpus", when you first pick a non-default location for the corpus (via `-fuzzdir=/some/path` or `-fuzzdir=testdata`), fzgo will seed that new non-default location with whatever it finds in `GOPATH/pkg/fuzz/corpus/...`  for the particular fuzz functions being run. This means you don't lose whatever you have found so far if you have been using `GOPATH/pkg/fuzz/corpus/...` for convenience.

In addition, whenever you fuzz, it uses the corpus from all known locations as input. For example, if you fuzz via `go test ./... -fuzz=. -fuzzdir=/some/path`, then any unique corpus elements found in `<pkg-path>/testdata/fuzz/<func>`, `GOPATH/pkg/fuzz/corpus/...`, or `/some/path` will all be used as input corpus for any matching fuzz functions.

(There is a asterisk on the last two paragraphs -- they describe what I am currently proposing as the behavior, but because dvyukov/go-fuzz does not actually support reading from multiple input corpus locations, fzgo currently approximates the proposed behavior, which is described the `copyCachedCorpus` [comment](https://github.com/thepudds/fzgo/blob/815abbde595f6a5543d89ded59dc76b694f8ae04/main.go#L329) in `main.go`. In short, it currently always copies any unique corpus files to whatever the destination corpus location is, which can be argued might actually be better behavior anyway).
