### PR TITLE
all: sync from private branch (genfuzzfuncs tweaks, printing args for rich funcs, etc.)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,17 @@ language: go
 matrix:
   include:
     - os: linux
-      go: "1.12.x"
+      go: "1.13.x"
     - os: linux
-      go: "1.11.x"
-    - os: osx
       go: "1.12.x"
     - os: osx
-      go: "1.11.x"
-    - os: windows
+      go: "1.13.x"
+    - os: osx
       go: "1.12.x"
     - os: windows
-      go: "1.11.x"
+      go: "1.13.x"
+    - os: windows
+      go: "1.12.x"
 
 before_install:
   - go get -v -u github.com/dvyukov/go-fuzz/...

--- a/fuzz/flag.go
+++ b/fuzz/flag.go
@@ -63,7 +63,6 @@ var IncompatibleTestFlags = []string{
 	"mutexprofilefraction", // -mutexprofilefraction n  (Sample 1 in n stack traces of goroutines holding a...)
 	"o",                    // -o file  (Compile the test binary to the named file.)
 	"outputdir",            // -outputdir directory  (Place output files from profiling in the specified directory,...)
-	"run",                  // -run regexp  (Run only those tests and examples matching the regular expression.)
 	"short",                // -short  (Tell long-running tests to shorten their run time.)
 	"trace",                // -trace trace.out  (Write an execution trace to the specified file before exiting.)
 	"vet",                  // -vet list  (Configure the invocation of "go vet" during "go test"...)
@@ -97,7 +96,9 @@ func ParseArgs(args []string, fs *flag.FlagSet) (string, error) {
 
 	// first, check if we are asked to do anything fuzzing-related by
 	// checking if -fuzz or -test.fuzz is present.
-	_, _, ok := FindTestFlag(args, []string{"fuzz"})
+	// also check if -run is passed, because we might being asked to
+	// verify a corpus.
+	_, _, ok := FindTestFlag(args, []string{"fuzz", "run"})
 	if !ok {
 		// nothing else to do for any fuzz-related args parsing.
 		return "", nil

--- a/fuzz/richsig_test.go
+++ b/fuzz/richsig_test.go
@@ -12,6 +12,7 @@ func TestWrapperGeneration(t *testing.T) {
 		pkgPattern     string
 		funcPattern    string
 		allowMultiFuzz bool
+		printArgs      bool
 	}
 	tests := []struct {
 		name       string
@@ -20,8 +21,12 @@ func TestWrapperGeneration(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:    "only basic types: string, []byte, bool",
-			args:    args{funcPattern: "FuzzWithBasicTypes", pkgPattern: "github.com/thepudds/fzgo/examples/richsignatures"},
+			name: "only basic types: string, []byte, bool",
+			args: args{
+				funcPattern: "FuzzWithBasicTypes",
+				pkgPattern:  "github.com/thepudds/fzgo/examples/richsignatures",
+				printArgs:   false,
+			},
 			wantErr: false,
 			wantOutput: `
 package richsigwrapper
@@ -61,8 +66,12 @@ func fuzzOne (fuzzer *randparam.Fuzzer) {
 `,
 		},
 		{
-			name:    "type from stdlib: regexp",
-			args:    args{funcPattern: "FuzzWithStdlibType", pkgPattern: "github.com/thepudds/fzgo/examples/richsignatures"},
+			name: "type from stdlib: regexp",
+			args: args{
+				funcPattern: "FuzzWithStdlibType",
+				pkgPattern:  "github.com/thepudds/fzgo/examples/richsignatures",
+				printArgs:   false,
+			},
 			wantErr: false,
 			wantOutput: `
 package richsigwrapper
@@ -105,8 +114,11 @@ func fuzzOne (fuzzer *randparam.Fuzzer) {
 `,
 		},
 		{
-			name:    "type from outside stdlib: github.com/fzgo/fuzz.Func",
-			args:    args{funcPattern: "FuzzWithFzgoFunc", pkgPattern: "github.com/thepudds/fzgo/examples/richsignatures"},
+			name: "type from outside stdlib: github.com/fzgo/fuzz.Func",
+			args: args{
+				funcPattern: "FuzzWithFzgoFunc",
+				pkgPattern:  "github.com/thepudds/fzgo/examples/richsignatures",
+			},
 			wantErr: false,
 			wantOutput: `
 package richsigwrapper
@@ -139,6 +151,54 @@ func fuzzOne (fuzzer *randparam.Fuzzer) {
 }
 `,
 		},
+		{
+			name: "print args with verbose",
+			args: args{
+				funcPattern: "FuzzWithBasicTypes",
+				pkgPattern:  "github.com/thepudds/fzgo/examples/richsignatures",
+				printArgs:   true,
+			},
+			wantErr: false,
+			wantOutput: `
+package richsigwrapper
+
+import "github.com/thepudds/fzgo/examples/richsignatures"
+
+import "github.com/thepudds/fzgo/randparam"
+
+// FuzzRichSigWrapper is an automatically generated wrapper that is
+// compatible with dvyukov/go-fuzz.
+func FuzzRichSigWrapper(data []byte) int {
+	fuzzer := randparam.NewFuzzer(data)
+	fuzzOne(fuzzer)
+	return 0
+}
+
+// fuzzOne is an automatically generated function that
+// uses fzgo/randparam.Fuzzer to automatically fuzz the arguments for a
+// user-supplied function.
+func fuzzOne (fuzzer *randparam.Fuzzer) {
+
+	// Create random args for each parameter from the signature.
+	// fuzzer.Fuzz recursively fills all of obj's fields with something random.
+	// Only exported (public) fields can be set currently. (That is how google/go-fuzz operates).
+	var re string
+	fuzzer.Fuzz(&re)
+	fmt.Printf("               arg 1:     %#v\n", re)
+
+	var input []byte
+	fuzzer.Fuzz(&input)
+	fmt.Printf("               arg 2:     %#v\n", input)
+
+	var posix bool
+	fuzzer.Fuzz(&posix)
+	fmt.Printf("               arg 3:     %#v\n", posix)
+
+	pkgname.FuzzWithBasicTypes(re, input, posix)
+
+}
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -147,7 +207,7 @@ func fuzzOne (fuzzer *randparam.Fuzzer) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("FindFunc() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			err = createWrapper(&b, functions[0])
+			err = createWrapper(&b, functions[0], tt.args.printArgs)
 			if err != nil {
 				t.Fatalf("createWrapper() error = %v", err)
 			}

--- a/genfuzzfuncs/constructor_injection_test.go
+++ b/genfuzzfuncs/constructor_injection_test.go
@@ -277,6 +277,7 @@ func Fuzz_NewBVal(c int) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			pkgPattern := "github.com/thepudds/fzgo/genfuzzfuncs/examples/test-constructor-injection"
 			options := flagExcludeFuzzPrefix | flagAllowMultiFuzz
 			if tt.onlyExported {

--- a/genfuzzfuncs/exported_test.go
+++ b/genfuzzfuncs/exported_test.go
@@ -206,6 +206,7 @@ func Fuzz_funcNotExported(i int) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			pkgPattern := "github.com/thepudds/fzgo/genfuzzfuncs/examples/test-exported"
 			options := flagExcludeFuzzPrefix | flagAllowMultiFuzz
 			if tt.onlyExported {

--- a/genfuzzfuncs/genfuzzfuncs.go
+++ b/genfuzzfuncs/genfuzzfuncs.go
@@ -293,13 +293,13 @@ func emitArgs(w io.Writer, sig *types.Signature, localPkg *types.Package, allWra
 		v := sig.Params().At(i)
 		paramName := avoidCollision(v, i, localPkg, allWrapperParams)
 		if i > 0 {
-			fmt.Fprintf(w, ", ")
+			fmt.Fprint(w, ", ")
 		}
-		fmt.Fprintf(w, paramName)
+		fmt.Fprint(w, paramName)
 	}
 	if sig.Variadic() {
 		// last argument needs an elipsis
-		fmt.Fprintf(w, "...")
+		fmt.Fprint(w, "...")
 	}
 }
 

--- a/genfuzzfuncs/genfuzzfuncs.go
+++ b/genfuzzfuncs/genfuzzfuncs.go
@@ -85,26 +85,16 @@ func createWrapper(w io.Writer, function fuzz.Func, possibleConstructors []fuzz.
 	if !ok {
 		return fmt.Errorf("function %s is not *types.Signature (%+v)", function, f)
 	}
-
-	// set up a types.Qualifier func we can use with the types package,
-	// paying attention to whether we are qualifying everything or not.
 	localPkg := f.Pkg()
-	localQualifier := func(pkg *types.Package) string {
-		if pkg == localPkg {
-			return ""
-		}
-		return pkg.Name()
-	}
-	var qualifier types.Qualifier
-	if qualifyAll {
-		qualifier = externalQualifier
-	} else {
-		qualifier = localQualifier
-	}
 
+	// set up types.Qualifier funcs we can use with the types package
+	// to scope variables by a package or not.
+	defaultQualifier, localQualifier := qualifiers(localPkg, qualifyAll)
+
+	// TODO: rename allParams to namespace? or possibleCollisions
 	// start building up our list of parameters we will use in input
 	// parameters to the new wrapper func we are about to emit.
-	var allWrapperParams []*types.Var
+	var allParams []*types.Var
 
 	// check if we have a receiver for the function under test, (i.e., testing a method)
 	// and then see if we can replace the receiver by finding
@@ -134,13 +124,13 @@ func createWrapper(w io.Writer, function fuzz.Func, possibleConstructors []fuzz.
 		if err != nil {
 			return err
 		}
-		allWrapperParams = append(allWrapperParams, paramsToAdd...)
+		allParams = append(allParams, paramsToAdd...)
 	}
 
 	// add in the parameters for the function under test.
 	for i := 0; i < wrappedSig.Params().Len(); i++ {
 		v := wrappedSig.Params().At(i)
-		allWrapperParams = append(allWrapperParams, v)
+		allParams = append(allParams, v)
 	}
 
 	// determine our wrapper name, which includes the receiver's type if we are wrapping a method.
@@ -160,11 +150,11 @@ func createWrapper(w io.Writer, function fuzz.Func, possibleConstructors []fuzz.
 
 	// check if we have an interface or function pointer in our desired parameters,
 	// we can't fill in with values during fuzzing.
-	if disallowedParams(w, allWrapperParams, wrapperName) {
+	if disallowedParams(w, allParams, wrapperName) {
 		// skip this wrapper, disallowedParams emitted a comment with more details.
 		return nil
 	}
-	if len(allWrapperParams) == 0 {
+	if len(allParams) == 0 {
 		// skip this wrapper, not useful for fuzzing if no inputs (no receiver, no parameters).
 		return nil
 	}
@@ -176,63 +166,59 @@ func createWrapper(w io.Writer, function fuzz.Func, possibleConstructors []fuzz.
 	// iterate over the our input parameters and emit.
 	// If we are a method, this includes either an object that is wrapped receiver's type,
 	// or it includes the parameters for a constructor if we found a suitable one.
-	for i, v := range allWrapperParams {
+	for i, v := range allParams {
 		// want: foo string, bar int
 		if i > 0 {
 			// need a comma if something has already been emitted
 			fmt.Fprint(w, ", ")
 		}
-		paramName := renameCollisions(v, i, localPkg, allWrapperParams)
-		typeStringWithSelector := types.TypeString(v.Type(), qualifier)
+		paramName := avoidCollision(v, i, localPkg, allParams)
+		typeStringWithSelector := types.TypeString(v.Type(), defaultQualifier)
 		fmt.Fprintf(w, "%s %s", paramName, typeStringWithSelector)
 	}
 	fmt.Fprint(w, ") {\n")
 
-	for i, v := range allWrapperParams {
-		// always crashing on a nil receiver is not particularly interesting, so emit the code to avoid.
-		// also check if we have any other pointer parameters.
-		// a user can decide to delete if they want to test nil recivers or nil parameters.
-		// also, could have a flag to disable.
-		_, ok := v.Type().(*types.Pointer)
-		if ok {
-			paramName := renameCollisions(v, i, localPkg, allWrapperParams)
-			fmt.Fprintf(w, "\tif %s == nil {\n", paramName)
-			fmt.Fprint(w, "\t\treturn\n")
-			fmt.Fprint(w, "\t}\n")
-		}
-	}
+	// Always crashing on a nil receiver is not particularly interesting, so emit the code to avoid.
+	// Also check if we have any other pointer parameters.
+	emitNilChecks(w, allParams, localPkg)
 
 	// emit a constructor if we have one
 	if ctorReplace.Sig != nil && recv != nil {
 		// insert our constructor!
-		fmt.Fprintf(w, "\t%s := ", renameCollisions(recv, 0, localPkg, allWrapperParams))
+		fmt.Fprintf(w, "\t%s := ", avoidCollision(recv, 0, localPkg, allParams))
 		if qualifyAll {
 			fmt.Fprintf(w, "%s.%s(", localPkg.Name(), ctorReplace.Func.Name())
 		} else {
 			fmt.Fprintf(w, "%s(", ctorReplace.Func.Name())
 		}
-		emitArgs(w, ctorReplace.Sig, localPkg, allWrapperParams)
+		emitArgs(w, ctorReplace.Sig, localPkg, allParams)
 		fmt.Fprintf(w, ")\n")
 	}
 
 	// emit the call to the wrapped function.
-	// this currently assumes it runs in the local package (that is, unqualified name)
-	if recv == nil {
-		if qualifyAll {
-			fmt.Fprintf(w, "\t%s.%s(", localPkg.Name(), f.Name())
-		} else {
-			fmt.Fprintf(w, "\t%s(", f.Name())
-		}
-	} else {
-		recvName := renameCollisions(recv, 0, localPkg, allWrapperParams)
-		fmt.Fprintf(w, "\t%s.%s(", recvName, f.Name())
-	}
+	emitWrappedFunc(w, f, wrappedSig, qualifyAll, allParams, localPkg)
 
-	// emit the arguments to the wrapped function.
-	emitArgs(w, wrappedSig, localPkg, allWrapperParams)
-	fmt.Fprint(w, ")\n}\n\n")
+	fmt.Fprint(w, "}\n\n")
 
 	return nil
+}
+
+// qualifiers sets up a types.Qualifier func we can use with the types package,
+// paying attention to whether we are qualifying everything or not.
+func qualifiers(localPkg *types.Package, qualifyAll bool) (defaultQualifier, localQualifier types.Qualifier) {
+
+	localQualifier = func(pkg *types.Package) string {
+		if pkg == localPkg {
+			return ""
+		}
+		return pkg.Name()
+	}
+	if qualifyAll {
+		defaultQualifier = externalQualifier
+	} else {
+		defaultQualifier = localQualifier
+	}
+	return defaultQualifier, localQualifier
 }
 
 // externalQualifier can be used as types.Qualifier in calls to types.TypeString and similar.
@@ -242,10 +228,10 @@ func externalQualifier(p *types.Package) string {
 	return p.Name()
 }
 
-// renameCollisions takes a variable (which might correpsond to a parameter or argument),
+// avoidCollision takes a variable (which might correpsond to a parameter or argument),
 // and returns a non-colliding name, or the original name, based on
 // whether or not it collided with package name or other with parameters.
-func renameCollisions(v *types.Var, i int, localPkg *types.Package, allWrapperParams []*types.Var) string {
+func avoidCollision(v *types.Var, i int, localPkg *types.Package, allWrapperParams []*types.Var) string {
 	// handle corner case of using the package name as a parameter name (e.g., flag.UnquoteUsage(flag *Flag)),
 	// or two parameters of the same name (e.g., if one was from a constructor and the other from the func under test).
 	paramName := v.Name()
@@ -264,12 +250,48 @@ func renameCollisions(v *types.Var, i int, localPkg *types.Package, allWrapperPa
 	return paramName
 }
 
+// emitNilChecks emits checks for nil for our input parameters.
+// Always crashing on a nil receiver is not particularly interesting, so emit the code to avoid.
+// Also check if we have any other pointer parameters.
+// A user can decide to delete if they want to test nil recivers or nil parameters.
+// Also, could have a flag to disable.
+func emitNilChecks(w io.Writer, allParams []*types.Var, localPkg *types.Package) {
+
+	for i, v := range allParams {
+		_, ok := v.Type().(*types.Pointer)
+		if ok {
+			paramName := avoidCollision(v, i, localPkg, allParams)
+			fmt.Fprintf(w, "\tif %s == nil {\n", paramName)
+			fmt.Fprint(w, "\t\treturn\n")
+			fmt.Fprint(w, "\t}\n")
+		}
+	}
+}
+
+// emitWrappedFunc emits the call to the function under test.
+func emitWrappedFunc(w io.Writer, f *types.Func, wrappedSig *types.Signature, qualifyAll bool, allParams []*types.Var, localPkg *types.Package) {
+	recv := wrappedSig.Recv()
+	if recv != nil {
+		recvName := avoidCollision(recv, 0, localPkg, allParams)
+		fmt.Fprintf(w, "\t%s.%s(", recvName, f.Name())
+	} else {
+		if qualifyAll {
+			fmt.Fprintf(w, "\t%s.%s(", localPkg.Name(), f.Name())
+		} else {
+			fmt.Fprintf(w, "\t%s(", f.Name())
+		}
+	}
+	// emit the arguments to the wrapped function.
+	emitArgs(w, wrappedSig, localPkg, allParams)
+	fmt.Fprint(w, ")\n")
+}
+
 // emitArgs emits the arguments needed to call a signature, including handling renaming arguments
 // based on collisions with package name or other parameters.
 func emitArgs(w io.Writer, sig *types.Signature, localPkg *types.Package, allWrapperParams []*types.Var) {
 	for i := 0; i < sig.Params().Len(); i++ {
 		v := sig.Params().At(i)
-		paramName := renameCollisions(v, i, localPkg, allWrapperParams)
+		paramName := avoidCollision(v, i, localPkg, allWrapperParams)
 		if i > 0 {
 			fmt.Fprintf(w, ", ")
 		}
@@ -312,7 +334,7 @@ func disallowedParams(w io.Writer, allWrapperParams []*types.Var, wrapperName st
 
 // ctorReplacement holds the signature of a suitable constructor if we found one.
 // We use the signature to "promote" the needed arguments from the constructor
-// parameter list up to the wrapper function paramete list.
+// parameter list up to the wrapper function parameter list.
 // Sig is nil if a suitable constructor was not found.
 type ctorReplacement struct {
 	Sig  *types.Signature
@@ -454,6 +476,7 @@ const (
 
 // FindFunc searches for requested functions matching a package pattern and func pattern.
 // TODO: this is a temporary fork from fzgo/fuzz.FindFunc.
+// TODO: maybe change flags to a predicate function?
 func FindFunc(pkgPattern, funcPattern string, env []string, flags FindFuncFlag) ([]fuzz.Func, error) {
 	report := func(err error) error {
 		return fmt.Errorf("error while loading packages for pattern %v: %v", pkgPattern, err)

--- a/genfuzzfuncs/long_test.go
+++ b/genfuzzfuncs/long_test.go
@@ -1,3 +1,5 @@
+// +build go1.13
+
 package main
 
 import (
@@ -9,7 +11,9 @@ import (
 
 func TestStrings(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode.")
+		// TODO: probably remove this test at some point?
+		// It is long, and sensitive to changes in stdlib strings pkg.
+		t.Skip("skipping test in short mode. also, currently relies on Go >= 1.13")
 	}
 	tests := []struct {
 		name               string
@@ -289,6 +293,10 @@ func Fuzz_ToUpper(s string) {
 
 func Fuzz_ToUpperSpecial(c unicode.SpecialCase, s string) {
 	strings.ToUpperSpecial(c, s)
+}
+
+func Fuzz_ToValidUTF8(s string, replacement string) {
+	strings.ToValidUTF8(s, replacement)
 }
 
 func Fuzz_Trim(s string, cutset string) {
@@ -593,6 +601,10 @@ func Fuzz_ToUpper(s string) {
 
 func Fuzz_ToUpperSpecial(c unicode.SpecialCase, s string) {
 	ToUpperSpecial(c, s)
+}
+
+func Fuzz_ToValidUTF8(s string, replacement string) {
+	ToValidUTF8(s, replacement)
 }
 
 func Fuzz_Trim(s string, cutset string) {
@@ -919,6 +931,10 @@ func Fuzz_ToUpper(s string) {
 
 func Fuzz_ToUpperSpecial(c unicode.SpecialCase, s string) {
 	strings.ToUpperSpecial(c, s)
+}
+
+func Fuzz_ToValidUTF8(s string, replacement string) {
+	strings.ToValidUTF8(s, replacement)
 }
 
 func Fuzz_Trim(s string, cutset string) {

--- a/genfuzzfuncs/long_test.go
+++ b/genfuzzfuncs/long_test.go
@@ -972,6 +972,7 @@ func Fuzz_TrimSuffix(s string, suffix string) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			pkgPattern := "strings"
 			options := flagExcludeFuzzPrefix | flagAllowMultiFuzz
 			if tt.onlyExported {
@@ -1000,3 +1001,4 @@ func Fuzz_TrimSuffix(s string, suffix string) {
 		})
 	}
 }
+

--- a/genfuzzfuncs/main.go
+++ b/genfuzzfuncs/main.go
@@ -50,7 +50,7 @@ should usaully be able to do so.
 func main() {
 	// handle flags
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, Usage)
+		fmt.Fprint(os.Stderr, Usage)
 		flag.PrintDefaults()
 	}
 	pkgFlag := flag.String("pkg", ".", "package pattern, defaults to current package")

--- a/genfuzzfuncs/main.go
+++ b/genfuzzfuncs/main.go
@@ -30,7 +30,7 @@ import (
 // Usage contains short usage information.
 var Usage = `
 usage:
-	genfuzzfuncs [-pkg=pkgPattern] [-func=regexp] [-unexported] [-qualifyall] 
+	genfuzzfuncs [-pkg=pkgPattern] [-func=regexp] [-unexported] [-qualifyall] [-ctors=false] [-ctorspattern=regexp]
 	
 Running genfuzzfuncs without any arguments targets the package in the current directory.
 
@@ -58,7 +58,7 @@ func main() {
 	unexportedFlag := flag.Bool("unexported", false, "emit wrappers for unexported functions in addition to exported functions")
 	qualifyAllFlag := flag.Bool("qualifyall", true, "all identifiers are qualified with package, including identifiers from the target package. "+
 		"If the package is '.' or not set, this defaults to false. Else, it defaults to true.")
-	constructorFlag := flag.Bool("ctors", false, "automatically insert constructors when wrapping a method call "+
+	constructorFlag := flag.Bool("ctors", true, "automatically insert constructors when wrapping a method call "+
 		"if a suitable constructor can be found in the same package.")
 	constructorPatternFlag := flag.String("ctorspattern", "^New", "regexp to use if searching for constructors to automatically use.")
 

--- a/randparam/randparam_test.go
+++ b/randparam/randparam_test.go
@@ -83,7 +83,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("string - two strings", func(t *testing.T) {
-		input := append([]byte{0x0, 0x1, 0x42, 0x2, 0x43, 0x44})
+		input := []byte{0x0, 0x1, 0x42, 0x2, 0x43, 0x44}
 		want1 := string([]byte{0x42})
 		want2 := string([]byte{0x43, 0x44})
 
@@ -101,7 +101,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("string - exactly run out of bytes", func(t *testing.T) {
-		input := append([]byte{0x0, 0x1, 0x42})
+		input := []byte{0x0, 0x1, 0x42}
 		want1 := string([]byte{0x42})
 		want2 := ""
 

--- a/randparam/randparam_test.go
+++ b/randparam/randparam_test.go
@@ -10,7 +10,7 @@ import (
 func TestFuzzingParams(t *testing.T) {
 
 	t.Run("string - 8 byte length, 8 bytes of string input", func(t *testing.T) {
-		input := append([]byte{0x8}, []byte("12345678")...)
+		input := append([]byte{0x0, 0x8}, []byte("12345678")...)
 		want := "12345678"
 
 		fuzzer := NewFuzzer(input)
@@ -22,7 +22,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("string - 9 byte length, 9 bytes of string input", func(t *testing.T) {
-		input := append([]byte{0x9}, []byte("123456789")...)
+		input := append([]byte{0x0, 0x9}, []byte("123456789")...)
 		want := "123456789"
 
 		fuzzer := NewFuzzer(input)
@@ -34,7 +34,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("string - 5 byte length, 6 bytes of string input", func(t *testing.T) {
-		input := append([]byte{0x5}, []byte("123456")...)
+		input := append([]byte{0x0, 0x5}, []byte("123456")...)
 		want := "12345"
 
 		fuzzer := NewFuzzer(input)
@@ -83,7 +83,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("string - two strings", func(t *testing.T) {
-		input := append([]byte{0x1, 0x42, 0x2, 0x43, 0x44})
+		input := append([]byte{0x0, 0x1, 0x42, 0x2, 0x43, 0x44})
 		want1 := string([]byte{0x42})
 		want2 := string([]byte{0x43, 0x44})
 
@@ -101,7 +101,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("string - exactly run out of bytes", func(t *testing.T) {
-		input := append([]byte{0x1, 0x42})
+		input := append([]byte{0x0, 0x1, 0x42})
 		want1 := string([]byte{0x42})
 		want2 := ""
 
@@ -119,7 +119,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("byte slice - 8 byte length, 8 input bytes", func(t *testing.T) {
-		input := append([]byte{0x8}, []byte("12345678")...)
+		input := append([]byte{0x0, 0x8}, []byte("12345678")...)
 		want := []byte("12345678")
 
 		fuzzer := NewFuzzer(input)
@@ -131,7 +131,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("byte slice - 3 byte length, 8 input bytes", func(t *testing.T) {
-		input := append([]byte{0x3}, []byte("12345678")...)
+		input := append([]byte{0x0, 0x3}, []byte("12345678")...)
 		want := []byte("123")
 
 		fuzzer := NewFuzzer(input)
@@ -143,9 +143,9 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("uint64 - 8 bytes input", func(t *testing.T) {
-		input := make([]byte, 8)
+		input := append([]byte{0x0}, make([]byte, 8)...)
 		i := uint64(0xfeedfacedeadbeef)
-		binary.LittleEndian.PutUint64(input, i)
+		binary.LittleEndian.PutUint64(input[1:], i)
 		want := uint64(0xfeedfacedeadbeef)
 
 		fuzzer := NewFuzzer(input)
@@ -157,7 +157,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("uint64 - 4 bytes input", func(t *testing.T) {
-		input := []byte{0xef, 0xbe, 0xad, 0xde}
+		input := []byte{0x0, 0xef, 0xbe, 0xad, 0xde}
 		want := uint64(0xdeadbeef)
 
 		fuzzer := NewFuzzer(input)
@@ -169,7 +169,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("int32 - 4 bytes input with zeros", func(t *testing.T) {
-		input := []byte{0x42, 0x00, 0x00, 0x00}
+		input := []byte{0x0, 0x42, 0x00, 0x00, 0x00}
 		want := int32(0x42)
 
 		fuzzer := NewFuzzer(input)
@@ -181,7 +181,7 @@ func TestFuzzingParams(t *testing.T) {
 	})
 
 	t.Run("int32 - 1 byte input", func(t *testing.T) {
-		input := []byte{0x42}
+		input := []byte{0x0, 0x42}
 		want := int32(0x42)
 
 		fuzzer := NewFuzzer(input)

--- a/testscripts/fuzzing_rich_signatures.txt
+++ b/testscripts/fuzzing_rich_signatures.txt
@@ -28,7 +28,7 @@ stdout 'building instrumented binary for pkgname.FuzzHardToGuessNumber'
 stderr 'workers: \d+, corpus: .* crashers: [^0]'
 exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzHardToGuessNumber/corpus
 
-# Check we can get a crasher relatively quickly by finding 2 long strings via a rich signature, which
+# Check we can get a crasher relatively quickly by finding a long string via a rich signature, which
 # is harder than the uint64 test. This relies on fzgo's approach
 # to deserializing working well with go-fuzz sonar's approach for variable length strings.
 # When working properly, this is typically found within 10 sec or so but sometimes 30 sec or so.
@@ -41,12 +41,14 @@ exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzHardToGuessNu
 # Seemed to get good results with 7f2a1780 if:
 #    used first byte for meta params, with 0x0 ==> fixed 2.
 #    had the gofuzz edit: f.nilChance == 0.0 {	return true	}
-# TODO: maybe skip harder FuzzHardToGuess2StringsInSlice, which is often 10-15 sec, but sometimes slow and times out on 1m.
-fzgo test -fuzz=FuzzHardToGuess2StringsInSlice example.com/richsignatures -parallel=2 -v -fuzztime=1m
-stdout 'building instrumented binary for pkgname.FuzzHardToGuess2StringsInSlice'
+# TODO: maybe skip harder FuzzHardToGuessStringInSlice, which is often 10-15 sec, 
+# but the two string version was sometimes slow and timed out on 1m.
+# We simplified the test to one string for now.
+fzgo test -fuzz=FuzzHardToGuessStringInSlice example.com/richsignatures -parallel=2 -v -fuzztime=1m
+stdout 'building instrumented binary for pkgname.FuzzHardToGuessStringInSlice'
 ! stdout 'randBytes verbose'
 stderr 'workers: \d+, corpus: .* crashers: [^0]'
-exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzHardToGuess2StringsInSlice/corpus
+exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzHardToGuessStringInSlice/corpus
 
 # Verify with no fzgo cache that we build the instrumented binary from scratch.
 # This also creates our corpus directory in the default location.
@@ -156,19 +158,12 @@ func FuzzHardToGuessNumber(guessMe int64) {
 	}
 }
 
-// FuzzHardToGuess2StringsInSlice is harder to get right, and relies on fzgo's approach
+// FuzzHardToGuessStringInSlice is harder to get right, and relies on fzgo's approach
 // to deserializing working well with go-fuzz sonar's approach for variable length strings.
 // This is typically found within a few seconds when working properly.
-func FuzzHardToGuess2StringsInSlice(list []string) {
-	found := 0
-	if len(list) > 0 && list[0] == "ZZZ it is hard to" {
-		found++
-	}
-	if len(list) > 1 && list[1] == "ZZZ guess this..." {
-		found++
-	}
-
-	if found == 2 {
+// Note: the string length should <= 20 to work with sonar.
+func FuzzHardToGuessStringInSlice(list []string) {
+	if len(list) > 0 && list[0] == "ZZZ hard to guess" {
 		panic("bingo")
 	}
 }

--- a/testscripts/fuzzing_rich_signatures.txt
+++ b/testscripts/fuzzing_rich_signatures.txt
@@ -7,13 +7,11 @@
 # Exit early if -short was specified.
 [short] skip 'skipping building instrumented binary because -short was specified'
 
-# get our dependencies
-go get -v -u github.com/thepudds/fzgo/...
+# get our dependencies. 
+# it should be sufficient to get fzgo/randparam, rather than fzgo/...
+# TODO: it would be better to use local copy. currently this gets the copy of fzgo/randparam from github.
+go get -v -u github.com/thepudds/fzgo/randparam
 go get -v -u github.com/google/gofuzz
-go get -v -u golang.org/x/tools/cmd/goimports
-
-# Verify goimports binary seems to exist in our test environment
-exists $WORK/gopath/bin/goimports$exe
 
 # Get go-fuzz (go-fuzz-dep needed by go-fuzz-build).
 go get -v -u github.com/dvyukov/go-fuzz/...
@@ -23,14 +21,42 @@ go install github.com/dvyukov/go-fuzz/...
 exists $WORK/gopath/bin/go-fuzz$exe
 exists $WORK/gopath/bin/go-fuzz-build$exe
 
-# First fuzz test: no fzgo cache, so we build the instrumented binary from scratch.
+# Check we can get a crasher relatively quickly by finding a 64 bit int via a rich signature, which
+# should imply go-fuzz literal injection is working end-to-end with fzgo's rich signatures.
+fzgo test -fuzz=FuzzHardToGuessNumber example.com/richsignatures -parallel=1 -fuzztime=10s
+stdout 'building instrumented binary for pkgname.FuzzHardToGuessNumber'
+stderr 'workers: \d+, corpus: .* crashers: [^0]'
+exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzHardToGuessNumber/corpus
+
+# Check we can get a crasher relatively quickly by finding 2 long strings via a rich signature, which
+# is harder than the uint64 test. This relies on fzgo's approach
+# to deserializing working well with go-fuzz sonar's approach for variable length strings.
+# When working properly, this is typically found within 10 sec or so but sometimes 30 sec or so.
+# This might have become slower between something like a March 2018 go-fuzz release vs. Aug 2018,
+# but not clear. It might just instead have high variance.
+# Also, versions after 'fc0bf08 go-fuzz-build: improve pkg resolution' avoid a gcc error that started
+# some time prior to that. Spot checked go-fuzz commits 7f2a1780, fc0bf087,  193030f.
+# go-fuzz-build with sha256 14288638034fb712... might have been faster than all of those.
+# I was likely using 7f2a1780 previously. 
+# Seemed to get good results with 7f2a1780 if:
+#    used first byte for meta params, with 0x0 ==> fixed 2.
+#    had the gofuzz edit: f.nilChance == 0.0 {	return true	}
+# TODO: maybe skip harder FuzzHardToGuess2StringsInSlice, which is often 10-15 sec, but sometimes slow and times out on 1m.
+fzgo test -fuzz=FuzzHardToGuess2StringsInSlice example.com/richsignatures -parallel=2 -v -fuzztime=1m
+stdout 'building instrumented binary for pkgname.FuzzHardToGuess2StringsInSlice'
+! stdout 'randBytes verbose'
+stderr 'workers: \d+, corpus: .* crashers: [^0]'
+exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzHardToGuess2StringsInSlice/corpus
+
+# Verify with no fzgo cache that we build the instrumented binary from scratch.
 # This also creates our corpus directory in the default location.
-fzgo test -fuzz=FuzzWithBasicTypes example.com/richsignatures -fuzztime=5s
+# We also specify -parallel=1 to reduce CPU usage for our remaining tests.
+fzgo test -fuzz=FuzzWithBasicTypes example.com/richsignatures -parallel=1 -fuzztime=5s
 stdout 'building instrumented binary for pkgname.FuzzWithBasicTypes'
 stderr 'workers: \d+, corpus: '
 exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzWithBasicTypes/corpus
 
-# Second fuzz test: now we use the fzgo cache.
+# Verify we now we use the fzgo cache.
 # We also specify -parallel=1 to reduce CPU usage for our remaining tests.
 fzgo test -fuzz=FuzzWithBasicTypes example.com/richsignatures -parallel=1 -fuzztime=5s
 stdout 'fzgo: using cached instrumented binary for pkgname.FuzzWithBasicTypes'
@@ -43,26 +69,27 @@ stdout 'fzgo: using cached instrumented binary for pkgname.FuzzWithBasicTypes'
 stderr 'workers: \d+, corpus: '
 exists $WORK/myfuzzdir/example.com/richsignatures/FuzzWithBasicTypes/corpus
 
-# Uncomment this next line if you don't want to rely on goimports
-# [!exec:goimports] stop 'skipping remaining step that currently relies on goimports being in the path'
-
-# Make sure goimports can be executed. 
-! exec goimports -h
-stderr 'goimports'
-
 # Check rich signature from stdlib (uses regexp)
-# This currently relies on goimports being in the path.
 fzgo test -fuzz=FuzzWithStdlibType example.com/richsignatures -parallel=1 -fuzztime=5s
 stdout 'building instrumented binary for pkgname.FuzzWithStdlibType'
 stderr 'workers: \d+, corpus: '
 exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzWithStdlibType/corpus
 
-# Check we can get a crasher relatively quickly by finding a 64 bit int via a rich signature, which
-# should imply go-fuzz literal injection is working end-to-end with fzgo's rich signatures.
-fzgo test -fuzz=FuzzHardToGuessNumber example.com/richsignatures -parallel=1 -fuzztime=10s
-stdout 'building instrumented binary for pkgname.FuzzHardToGuessNumber'
-stderr 'workers: \d+, corpus: .* crashers: [^0]'
-exists $WORK/gopath/pkg/fuzz/corpus/example.com/richsignatures/FuzzHardToGuessNumber/corpus
+# Verify we can use -run flag to select a specific file from the corpus for a rich signature.
+# We will guess that we have a zero length file. (Probably it will consistently be there, but we'll see).
+# This relies on go-fuzz SHA256 calc being stable.
+# We are not time limiting this, so this also relies on us interpreting -run to mean verify corpus
+# (otherwise, this will never return until the testscript package times out at 10 minutes or so).
+fzgo test -v -run=TestCorpus/da39a3ee5e6b4 -fuzz=FuzzHardToGuessNumber example.com/richsignatures
+stdout '=== RUN   TestCorpus/da39a3ee5e6b4'
+stdout '--- PASS: TestCorpus/da39a3ee5e6b4'
+stdout '^ok .*fzgo-verify-corpus'
+
+# Check a signature that almost matches a plain 'func([]byte) int' signature.
+fzgo test -fuzz=FuzzAlmostPlain example.com/richsignatures -parallel=1 -fuzztime=5s
+stdout 'detected rich signature for pkgname.FuzzAlmostPlain'
+stdout 'building instrumented binary for pkgname.FuzzAlmostPlain'
+stderr 'workers: \d+, corpus: .*'
 
 # NOTE: currently this is cloned from examples dir in fzgo repo. (Probably good to have locally here?)
 
@@ -115,11 +142,33 @@ func FuzzWithTargetType(e ExampleType) {
 
 }
 
+// FuzzAlmostPlain excercises our rich sig detection logic slightly more as a "near miss" to an older-style sig.
+func FuzzAlmostPlain(data []byte) string {
+	return ""
+}
+
 // FuzzHardToGuessNumber is a sanity check that go-fuzz literal injection seems to be working end-to-end.
 // This is typically found within a few seconds when properly hooked up.
 func FuzzHardToGuessNumber(guessMe int64) {
 
 	if guessMe == 0x123456789 {
+		panic("bingo")
+	}
+}
+
+// FuzzHardToGuess2StringsInSlice is harder to get right, and relies on fzgo's approach
+// to deserializing working well with go-fuzz sonar's approach for variable length strings.
+// This is typically found within a few seconds when working properly.
+func FuzzHardToGuess2StringsInSlice(list []string) {
+	found := 0
+	if len(list) > 0 && list[0] == "ZZZ it is hard to" {
+		found++
+	}
+	if len(list) > 1 && list[1] == "ZZZ guess this..." {
+		found++
+	}
+
+	if found == 2 {
 		panic("bingo")
 	}
 }

--- a/testscripts/verify_corpus.txt
+++ b/testscripts/verify_corpus.txt
@@ -13,6 +13,7 @@ go get -v -u github.com/thepudds/fzgo/examples/...
 # Verify the corpus for FuzzTime. This automatically also passes through to
 # the normal 'go test', which causes it to report 'no test files'
 fzgo test github.com/thepudds/fzgo/examples/time
+exists $WORK/gopath/src/github.com/thepudds/fzgo/examples/time/testdata/fuzz/FuzzTime
 stdout '^ok .*fzgo-verify-corpus'
 stdout 'github.com/thepudds/fzgo/examples/time.*\[no test files\]'
 
@@ -28,8 +29,3 @@ stdout 'github.com/thepudds/fzgo/examples/time.*\[no test files\]'
 fzgo test github.com/thepudds/fzgo/examples/empty
 ! stdout 'fzgo-verify-corpus'
 stdout 'github.com/thepudds/fzgo/examples/empty.*\[no test files\]'
-
-# TODO: maybe try png? Might not currently won't work due to corpus layout?
-# go get -v -u github.com/dvyukov/go-fuzz-corpus/png
-# fzgo test github.com/dvyukov/go-fuzz-corpus/png
-# stdout '^ok .*fzgo-verify-corpus'


### PR DESCRIPTION
Sync from one of the private branches, including partial genfuzzfuncs refactor, using constructors defaulting to on for genfuzzfuncs, optionally printing args for rich funcs based on -v and -run, stop invoking goimports, etc.