### PR TITLE
testing: install golang.org/x/mod/... manually

### DIFF
--- a/testscripts/fuzzing_rich_signatures.txt
+++ b/testscripts/fuzzing_rich_signatures.txt
@@ -13,6 +13,9 @@
 go get -v -u github.com/thepudds/fzgo/randparam
 go get -v -u github.com/google/gofuzz
 
+# TODO: at some point between 2019-11-03 and 2020-02-15, this became a needed workaround.
+go get -v -u golang.org/x/mod/...
+
 # Get go-fuzz (go-fuzz-dep needed by go-fuzz-build).
 go get -v -u github.com/dvyukov/go-fuzz/...
 go install github.com/dvyukov/go-fuzz/...


### PR DESCRIPTION
An upstream change in golang.org/x/tools started causing problems.

This commit resolves the following error for fuzzing_rich_signatures test.

```
Test fuzzing rich sigs. We could assume go-fuzz and go-fuzz-build binaries are in the path,
            [stdout]
            fzgo: package load error for package pattern example.com/richsignatures
            [stderr]
            gopath/src/golang.org/x/tools/internal/imports/mod.go:17:2: cannot find package "golang.org/x/mod/module" in any of:
                /usr/local/go/src/golang.org/x/mod/module (from $GOROOT)
                $WORK/gopath/src/golang.org/x/mod/module (from $GOPATH)
            gopath/src/golang.org/x/tools/internal/imports/mod.go:18:2: cannot find package "golang.org/x/mod/semver" in any of:
                /usr/local/go/src/golang.org/x/mod/semver (from $GOROOT)
                $WORK/gopath/src/golang.org/x/mod/semver (from $GOPATH)
            $WORK/gopath/src/golang.org/x/tools/internal/imports/mod.go:17:2: could not import golang.org/x/mod/module (invalid package name: "")
            $WORK/gopath/src/golang.org/x/tools/internal/imports/mod.go:18:2: could not import golang.org/x/mod/semver (invalid package name: "")
            [exit status 1]
            FAIL: testscripts/fuzzing_rich_signatures.txt:26: unexpected command failure
```