### PR TITLE
travis: update to newer Go versions, disable modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,14 @@ matrix:
       go: "1.15.x"
     - os: linux
       go: "1.14.x"
-    - os: linux
-      go: "1.13.x"
     - os: osx
       go: "1.16.x"
     - os: osx
-      go: "1.13.x"
+      go: "1.15.x"
     - os: windows
       go: "1.16.x"
     - os: windows
-      go: "1.13.x"
+      go: "1.15.x"
 
 before_install:
   - go get -v -u github.com/dvyukov/go-fuzz/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+# fzgo is not yet a proper module, including the tests would need to be updated.
+env:
+  - GO111MODULE=off
+  
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,17 @@ language: go
 matrix:
   include:
     - os: linux
-      go: "1.13.x"
+      go: "1.16.x"
     - os: linux
-      go: "1.12.x"
-    - os: osx
       go: "1.13.x"
     - os: osx
-      go: "1.12.x"
-    - os: windows
+      go: "1.16.x"
+    - os: osx
       go: "1.13.x"
     - os: windows
-      go: "1.12.x"
+      go: "1.16.x"
+    - os: windows
+      go: "1.13.x"
 
 before_install:
   - go get -v -u github.com/dvyukov/go-fuzz/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ matrix:
     - os: linux
       go: "1.16.x"
     - os: linux
+      go: "1.15.x"
+    - os: linux
+      go: "1.14.x"
+    - os: linux
       go: "1.13.x"
     - os: osx
       go: "1.16.x"

--- a/genfuzzfuncs/long_test.go
+++ b/genfuzzfuncs/long_test.go
@@ -211,8 +211,8 @@ func Fuzz_IndexRune(s string, r rune) {
 	strings.IndexRune(s, r)
 }
 
-func Fuzz_Join(a []string, sep string) {
-	strings.Join(a, sep)
+func Fuzz_Join(elems []string, sep string) {
+	strings.Join(elems, sep)
 }
 
 func Fuzz_LastIndex(s string, substr string) {
@@ -519,8 +519,8 @@ func Fuzz_IndexRune(s string, r rune) {
 	IndexRune(s, r)
 }
 
-func Fuzz_Join(a []string, sep string) {
-	Join(a, sep)
+func Fuzz_Join(elems []string, sep string) {
+	Join(elems, sep)
 }
 
 func Fuzz_LastIndex(s string, substr string) {
@@ -849,8 +849,8 @@ func Fuzz_IndexRune(s string, r rune) {
 	strings.IndexRune(s, r)
 }
 
-func Fuzz_Join(a []string, sep string) {
-	strings.Join(a, sep)
+func Fuzz_Join(elems []string, sep string) {
+	strings.Join(elems, sep)
 }
 
 func Fuzz_LastIndex(s string, substr string) {

--- a/testscripts/fuzzing.txt
+++ b/testscripts/fuzzing.txt
@@ -11,6 +11,9 @@
 # Exit early if -short was specified.
 [short] skip 'skipping building instrumented binary because -short was specified'
 
+# Explicitly set GO111MODULE off for now. (testscripts seemingly by design do not pick up this value from actual env).
+env GO111MODULE=off
+
 # Get go-fuzz (go-fuzz-dep needed by go-fuzz-build).
 go get -v -u github.com/dvyukov/go-fuzz/...
 go install github.com/dvyukov/go-fuzz/...

--- a/testscripts/fuzzing_rich_signatures.txt
+++ b/testscripts/fuzzing_rich_signatures.txt
@@ -7,6 +7,9 @@
 # Exit early if -short was specified.
 [short] skip 'skipping building instrumented binary because -short was specified'
 
+# Explicitly set GO111MODULE off for now. (testscripts seemingly by design do not pick up this value from actual env).
+env GO111MODULE=off
+
 # get our dependencies. 
 # it should be sufficient to get fzgo/randparam, rather than fzgo/...
 # TODO: it would be better to use local copy. currently this gets the copy of fzgo/randparam from github.

--- a/testscripts/package_patterns.txt
+++ b/testscripts/package_patterns.txt
@@ -9,6 +9,9 @@
 # across multiple packages. However, these tests were built before that change, 
 # so we use the -debug=nomultifuzz option below to preserve the original behavior.
 
+# Output the current env to help with any debugging (e.g., what is GO111MODULE)
+env
+
 # Fail when more than one fuzz func matches in two different packages.
 ! fzgo test -fuzz=FuzzTwo ./... -fuzztime=10s -debug=nomultifuzz
 stdout '^fzgo: multiple matches not allowed'

--- a/testscripts/package_patterns.txt
+++ b/testscripts/package_patterns.txt
@@ -9,7 +9,7 @@
 # across multiple packages. However, these tests were built before that change, 
 # so we use the -debug=nomultifuzz option below to preserve the original behavior.
 
-# Output the current env to help with any debugging (e.g., what is GO111MODULE)
+# Explicitly set GO111MODULE off for now. (testscripts seemingly by design do not pick up this value from actual env).
 env GO111MODULE=off
 
 # Fail when more than one fuzz func matches in two different packages.

--- a/testscripts/package_patterns.txt
+++ b/testscripts/package_patterns.txt
@@ -10,7 +10,7 @@
 # so we use the -debug=nomultifuzz option below to preserve the original behavior.
 
 # Output the current env to help with any debugging (e.g., what is GO111MODULE)
-env
+env GO111MODULE=off
 
 # Fail when more than one fuzz func matches in two different packages.
 ! fzgo test -fuzz=FuzzTwo ./... -fuzztime=10s -debug=nomultifuzz

--- a/testscripts/verify_corpus.txt
+++ b/testscripts/verify_corpus.txt
@@ -7,6 +7,9 @@
 #     go test -run=TestScript/verify_corpus
 # (permuatations like -run=TestScript/corpus or -run=TestScript/.*corpus.* should also work)
 
+# Explicitly set GO111MODULE off for now. (testscripts seemingly by design do not pick up this value from actual env).
+env GO111MODULE=off
+
 # Download the FuzzTime example from the fzgo repo
 go get -v -u github.com/thepudds/fzgo/examples/...
 


### PR DESCRIPTION
fzgo is not yet a proper module, which would require updating the tests.